### PR TITLE
fix： 修复菜单管理的bug

### DIFF
--- a/src/views/admin/menu/MenuForm.vue
+++ b/src/views/admin/menu/MenuForm.vue
@@ -1,6 +1,7 @@
 <template>
   <el-dialog
     :title="form.id ? '编辑菜单': '新建菜单'"
+    :close-on-click-modal="false"
     :visible.sync="dialogVisible"
     :before-close="closeDialog"
     width="600px">
@@ -19,7 +20,7 @@
       <el-form-item label="Title">
         <el-input v-model="form.title"></el-input>
       </el-form-item>
-      <el-form-item label="路径">
+      <el-form-item label="路由路径">
         <el-input v-model="form.path"></el-input>
       </el-form-item>
       <el-form-item label="图标">
@@ -88,11 +89,14 @@ export default {
         title: '',
         path: ''
       })
-    }
+    },
+    menuOptions: {
+      type: Array,
+      default: () => []
+    },
   },
   data() {
     return {
-      menuOptions: [],
     }
   },
   computed: {
@@ -100,7 +104,7 @@ export default {
   created() {
   },
   mounted() {
-    this.getTreeSelect()
+    console.log(this.menuOptions)
   },
   methods: {
     // 选择图标

--- a/src/views/admin/menu/MenuForm.vue
+++ b/src/views/admin/menu/MenuForm.vue
@@ -104,7 +104,6 @@ export default {
   created() {
   },
   mounted() {
-    console.log(this.menuOptions)
   },
   methods: {
     // 选择图标
@@ -121,15 +120,6 @@ export default {
         label: node.meta.title,
         children: node.children
       }
-    },
-
-    // 树形选择器结构
-    async getTreeSelect() {
-      this.menuOptions = []
-      const res = (await RouteModel.getRouteTree()) || []
-      const menu = { id: 0, meta: { title: '主类目' }, children: [] }
-      menu.children = [...res]
-      this.menuOptions.push(menu)
     },
 
     closeDialog() {

--- a/src/views/admin/menu/index.vue
+++ b/src/views/admin/menu/index.vue
@@ -81,7 +81,6 @@ export default {
   created() { },
   mounted() {
     this.getRouteTree()
-    // this.getTreeSelect()
   },
   methods: {
     // 树形选择器结构

--- a/src/views/admin/menu/index.vue
+++ b/src/views/admin/menu/index.vue
@@ -41,7 +41,11 @@
       </el-col>
     </el-row>
 
-    <MenuForm :dialog-visible="dialogVisible" :form="form" @closeDialog="closeDialog" @handleSubmit="onSubmit"></MenuForm>
+    <MenuForm
+      :dialog-visible="dialogVisible"
+      :form="form"
+      :menu-options="menuOptions"
+      @closeDialog="closeDialog" @handleSubmit="onSubmit"></MenuForm>
 
   </div>
 </template>
@@ -77,14 +81,24 @@ export default {
   created() { },
   mounted() {
     this.getRouteTree()
+    // this.getTreeSelect()
   },
   methods: {
-
+    // 树形选择器结构
+    async getTreeSelect() {
+      let options = []
+      const res = (await RouteModel.getRouteTree()) || []
+      const menu = { id: 0, meta: { title: '主类目' }, children: [] }
+      menu.children = [...res]
+      options.push(menu)
+      this.menuOptions = options
+    },
     async getRouteTree() {
       try {
         const res = (await RouteModel.getRouteTree()) || []
         this.routeTree = [...res]
         this.dragFlag = false
+        this.getTreeSelect()
       } catch (e) {
         console.log(e)
       }


### PR DESCRIPTION
- 修改表单label“路径”为“路由路径”
- 不可以通过点击 modal 关闭 Dialog
- 对菜单修改后，表单内的路由树会同步更新了